### PR TITLE
ID-95 Create embargo entities from i7 embargo data

### DIFF
--- a/022-embargoes/README.md
+++ b/022-embargoes/README.md
@@ -1,0 +1,37 @@
+
+Get the embargo values for every PID in solr and save in `embargoes.csv`
+
+```
+for F in $(ls output); do
+  jq -r '.response.docs[] | [.PID, .mods_originInfo_encoding_iso8601_qualifier_embargo_dateValid_dt, ."RELS_INT_embargo-expiry-notification-date_literal_s", ."RELS_INT_embargo-until_literal_s"] | @csv' output/$F | grep -v ",,,"
+done > embargoes.csv
+```
+
+Get the nid<->pid mapping and save in `pids.csv`
+
+```
+SELECT entity_id, pid from _i7_pids i7
+LEFT JOIN node__field_pid i2 ON i2.field_pid_value = i7.pid
+WHERE i2.field_pid_value IS NOT NULL;
+```
+
+Get the vid<->pid mapping and save in `revisions.csv`
+```
+SELECT revision_id, pid from _i7_pids i7
+LEFT JOIN node__field_pid i2 ON i2.field_pid_value = i7.pid
+WHERE i2.field_pid_value IS NOT NULL;
+```
+
+Create a SQL command to update the node metadata with the i7 content
+
+```
+go run main.go
+```
+
+Run the SQL!
+
+Then create the embargo entities
+
+```
+drush scr embargoes.php
+```

--- a/022-embargoes/embargoes.php
+++ b/022-embargoes/embargoes.php
@@ -1,0 +1,17 @@
+<?php
+
+use Drupal\embargo\Entity\Embargo;
+use Drupal\embargo\EmbargoInterface;
+
+$results = \Drupal::database()->query("SELECT entity_id, field_embargo_expiry_value
+  FROM node__field_embargo_expiry");
+foreach ($results as $row) {
+  $embargo = Embargo::create([
+    'embargo_type' => EmbargoInterface::EMBARGO_TYPE_FILE,
+    'expiration_type' => EmbargoInterface::EXPIRATION_TYPE_SCHEDULED,
+    'expiration_date' => explode('T', $row->field_embargo_expiry_value)[0],
+    'embargoed_node' => $row->entity_id,
+  ]);
+
+  $embargo->save();
+}

--- a/022-embargoes/main.go
+++ b/022-embargoes/main.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bufio"
+	"encoding/csv"
+	"fmt"
+	"io"
+	"log"
+	"os"
+)
+
+var (
+	pids = map[string]string{}
+	vids = map[string]string{}
+)
+
+func init() {
+	cacheCsv(pids, "pids.csv")
+	cacheCsv(vids, "revisions.csv")
+}
+
+func cacheCsv(m map[string]string, f string) {
+	file, err := os.Open(f)
+	if err != nil {
+		fmt.Println("Error opening CSV file:", err)
+		return
+	}
+	defer file.Close()
+
+	reader := csv.NewReader(file)
+
+	// skip header
+	reader.Read()
+
+	for {
+		record, err := reader.Read()
+		if err != nil {
+			break
+		}
+		if len(record) == 2 {
+			m[record[1]] = record[0]
+		}
+	}
+}
+
+func main() {
+	inputFilePath := "embargoes.csv"
+	outputFilePath := "update.sql"
+
+	inputFile, err := os.Open(inputFilePath)
+	if err != nil {
+		fmt.Println("Error opening input file:", err)
+		return
+	}
+	defer inputFile.Close()
+
+	outputFile, err := os.Create(outputFilePath)
+	if err != nil {
+		fmt.Println("Error creating output file:", err)
+		return
+	}
+	defer outputFile.Close()
+
+	csvReader := csv.NewReader(inputFile)
+	w := bufio.NewWriter(outputFile)
+
+	// skip header
+	csvReader.Read()
+
+	tables := []string{
+		"node__field_embargo_expiry",
+		"node_revision__field_embargo_expiry",
+	}
+	for {
+		record, err := csvReader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			fmt.Println("Error reading CSV:", err)
+			return
+		}
+		// pid,embargo
+		nid, nidFound := pids[record[0]]
+		vid, vidFound := vids[record[0]]
+
+		if !nidFound || !vidFound || nid == "" || vid == "" {
+			log.Fatalf("Missing nid<->pid mapping for %s", record[0])
+		}
+
+		for _, table := range tables {
+			sql := fmt.Sprintf(`INSERT INTO %s (bundle, deleted, entity_id, revision_id, langcode, delta, field_embargo_expiry_value)
+			VALUES
+				('islandora_object', 0, %s, %s, 'en', 0, '%s');
+`, table, nid, vid, record[1])
+			if _, err := w.WriteString(sql); err != nil {
+				fmt.Println("Error writing SQL:", err)
+				return
+			}
+		}
+	}
+
+	w.Flush()
+
+	fmt.Println("SQL transformation complete. Output written to", outputFilePath)
+}


### PR DESCRIPTION
Islandora Workbench does not integrate with [Discoverygarden's embargo module](https://github.com/discoverygarden/embargo).

So create a script to extract the embargo data from the i7 documents, then import this data into a field for display, along with creating the proper entities to restrict access.